### PR TITLE
fix: horizontal overflow

### DIFF
--- a/app/components/banner.tsx
+++ b/app/components/banner.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 
 export const Banner: React.FC = () => {
   return (
-    <div className="w-screen bg-black font-display">
+    <div className="w-full bg-black font-display">
       <div className="container flex items-center justify-center px-4 py-2 mx-auto text-sm text-stone-50 ">
         <Link className="hover:underline" target="_blank" href="https://github.com/chronark/starlog">
           STARLOG is open source on <span className="font-medium">GitHub</span>


### PR DESCRIPTION
Fixes horizontal overflow issue on Windows by changing the class from 'w-screen' to 'w-full'

![Screenshot (143)](https://user-images.githubusercontent.com/111579522/213923079-cd04cb1e-ad09-4acd-98d0-fb6d4ebe3af4.png)
